### PR TITLE
add logic to set TARGET_BOOTLOADER_BOARD_NAME

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -14,7 +14,14 @@
 
 include device/sony/tama/PlatformConfig.mk
 
-TARGET_BOOTLOADER_BOARD_NAME := tama
+TARGET_BOOTLOADER_BOARD_NAME := unknown
+ifneq (,$(filter %h8216,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := H8216
+else ifneq (,$(filter %h8266,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := H8266
+else
+$(error Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)")
+endif
 
 # Platform
 PRODUCT_PLATFORM := tama


### PR DESCRIPTION
Set TARGET_BOOTLOADER_BOARD_NAME to the variant-specific board-name
(i.e. H8216, H8266).  This causes the "board" variable in
"android-info.txt" to be populated correctly, which fixes
updatepackage zips.