### PR TITLE
rootdir: Move uinput-fpc.kl from platform

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -59,6 +59,10 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/firmware/touch_module_id_0x20.img:$(TARGET_COPY_OUT_VENDOR)/firmware/touch_module_id_0x20.img \
     $(DEVICE_PATH)/vendor/firmware/touch_module_id_0x21.img:$(TARGET_COPY_OUT_VENDOR)/firmware/touch_module_id_0x21.img
 
+# FPC Gestures
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/usr/keylayout/uinput-fpc.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/uinput-fpc.kl
+
 # Device Init
 PRODUCT_PACKAGES += \
     fstab.akari \

--- a/rootdir/vendor/usr/keylayout/uinput-fpc.kl
+++ b/rootdir/vendor/usr/keylayout/uinput-fpc.kl
@@ -1,0 +1,16 @@
+#key 103   SYSTEM_NAVIGATION_UP
+#key 108   SYSTEM_NAVIGATION_DOWN
+# Left and right are swapped, because this is a back-mounted sensor.
+# In other words, the sensor is mirrored relative to the screen.
+#key 106   SYSTEM_NAVIGATION_LEFT
+#key 105   SYSTEM_NAVIGATION_RIGHT
+
+# Akari and Akatsuki, as seen from the front
+#
+#             103
+#              ^
+#              |
+#    106 <-----|-----> 105
+#              |
+#              v
+#             108


### PR DESCRIPTION
Apollo's fingerprint sensor is rotated 90 degrees clockwise, as compared to Akari and Akatsuki.

This necessitates two different config files, and as such, the keylayout configs are moved to the individual device gits.